### PR TITLE
Add Vue component test helpers and related unit tests with index file

### DIFF
--- a/src/__test__/helpers/test/mount.spec.ts
+++ b/src/__test__/helpers/test/mount.spec.ts
@@ -1,0 +1,251 @@
+import { defineStore } from 'pinia';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { defineComponent, h, ref, computed, defineAsyncComponent, nextTick } from 'vue';
+import { mockedStore, mountComponent, mountSuspendedComponent, setupTestingPinia } from '@/helpers/test';
+
+const TestComponent = defineComponent({
+  props: {
+    message: {
+      type: String,
+      default: 'Default Message',
+    },
+  },
+  setup(props) {
+    const count = ref(0);
+    const doubledCount = computed(() => count.value * 2);
+
+    const increment = () => {
+      count.value++;
+    };
+
+    return {
+      count,
+      doubledCount,
+      increment,
+      message: props.message,
+    };
+  },
+  render() {
+    return h('div', [
+      h('h1', this.message),
+      h('p', `Count: ${this.count}`),
+      h('p', `Doubled: ${this.doubledCount}`),
+      h('button', { onClick: this.increment }, 'Increment'),
+    ]);
+  },
+});
+
+const AsyncComponent = defineComponent({
+  setup() {
+    const asyncData = ref('Async Data');
+    return { asyncData };
+  },
+  render() {
+    return h('div', [h('p', `Async data: ${this.asyncData}`)]);
+  },
+});
+
+const AsyncTestComponent = defineAsyncComponent(() => Promise.resolve(AsyncComponent));
+
+const SlottedComponent = defineComponent({
+  render() {
+    return h('div', [
+      h('header', {}, this.$slots.header ? this.$slots.header() : 'Default Header'),
+      h('main', {}, this.$slots.default ? this.$slots.default() : 'Default Content'),
+      h('footer', {}, this.$slots.footer ? this.$slots.footer() : 'Default Footer'),
+    ]);
+  },
+});
+
+const ChildComponent = defineComponent({
+  render() {
+    return h('div', 'Child Component');
+  },
+});
+
+const ParentComponent = defineComponent({
+  components: {
+    ChildComponent,
+  },
+  render() {
+    return h('div', [h('h1', 'Parent Component'), h(ChildComponent)]);
+  },
+});
+
+const CustomButton = defineComponent({
+  name: 'CustomButton',
+  render() {
+    return h('button', 'Complex Button');
+  },
+});
+
+const StubTestComponent = defineComponent({
+  components: {
+    CustomButton,
+  },
+  render() {
+    return h('div', [h('h1', 'Main Component'), h(CustomButton)]);
+  },
+});
+
+const MockTestComponent = defineComponent({
+  methods: {
+    navigate() {
+      this.$router.push('/test');
+    },
+  },
+  render() {
+    return h('button', { onClick: this.navigate }, 'Navigate');
+  },
+});
+
+const useCounterStore = defineStore('counter', {
+  state: () => ({
+    globalCount: 0,
+  }),
+  actions: {
+    increment() {
+      this.globalCount++;
+    },
+  },
+});
+
+const StoreComponent = defineComponent({
+  setup() {
+    const store = useCounterStore();
+
+    return {
+      store,
+      incrementGlobal: () => store.increment(),
+    };
+  },
+  render() {
+    return h('div', [
+      h('p', `Global count: ${this.store.globalCount}`),
+      h('button', { onClick: this.incrementGlobal }, 'Increment Global'),
+    ]);
+  },
+});
+
+describe('src/helpers/test/mount.ts', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('can mount a basic component', async () => {
+    const wrapper = mountComponent(TestComponent);
+
+    expect(wrapper.find('h1').text()).toBe('Default Message');
+    expect(wrapper.find('p').text()).toBe('Count: 0');
+
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.find('p').text()).toBe('Count: 1');
+  });
+
+  test('can mount a component with props', async () => {
+    const wrapper = mountComponent(TestComponent, {
+      props: { message: 'Custom Message' },
+    });
+
+    expect(wrapper.find('h1').text()).toBe('Custom Message');
+  });
+
+  test('can access component instance and verify values', async () => {
+    interface TestComponentInstance {
+      doubledCount: number;
+      increment: () => void;
+      message: string;
+    }
+
+    const wrapper = mountComponent<TestComponentInstance>(TestComponent);
+
+    expect(wrapper.vm.doubledCount).toBe(0);
+
+    wrapper.vm.increment();
+    await nextTick();
+
+    expect(wrapper.vm.doubledCount).toBe(2);
+    expect(wrapper.vm.message).toBe('Default Message');
+  });
+
+  test('can correctly mount async components', async () => {
+    const wrapper = await mountSuspendedComponent(AsyncTestComponent);
+
+    expect(wrapper.find('p').text()).toBe('Async data: Async Data');
+  });
+
+  test('can customize component content using slots', async () => {
+    const wrapper = await mountSuspendedComponent(SlottedComponent, {
+      slots: {
+        header: () => 'Custom Header',
+        default: () => 'Custom Content',
+        footer: () => 'Custom Footer',
+      },
+    });
+
+    expect(wrapper.find('header').text()).toBe('Custom Header');
+    expect(wrapper.find('main').text()).toBe('Custom Content');
+    expect(wrapper.find('footer').text()).toBe('Custom Footer');
+  });
+
+  test('can test components that use Pinia store', async () => {
+    const testingPinia = setupTestingPinia();
+    const wrapper = await mountSuspendedComponent(StoreComponent, { testingPinia });
+
+    expect(wrapper.find('p').text()).toBe('Global count: 0');
+
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.find('p').text()).toBe('Global count: 1');
+
+    const store = mockedStore(useCounterStore);
+
+    expect(store.increment).toHaveBeenCalledTimes(1);
+    expect(store.globalCount).toBe(1);
+  });
+
+  test('can test components with a Pinia store that has initial values', async () => {
+    const testingPinia = setupTestingPinia({
+      counter: { globalCount: 10 },
+    });
+
+    const wrapper = await mountSuspendedComponent(StoreComponent, { testingPinia });
+
+    expect(wrapper.find('p').text()).toBe('Global count: 10');
+  });
+
+  test('can stub child components using the shallow option', async () => {
+    const wrapper = await mountSuspendedComponent(ParentComponent, {
+      shallow: true,
+    });
+
+    expect(wrapper.findComponent(ChildComponent).exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('Child Component');
+  });
+
+  test('can stub specific components only', async () => {
+    const wrapper = await mountSuspendedComponent(StubTestComponent, {
+      stubs: {
+        CustomButton: true,
+      },
+    });
+
+    expect(wrapper.findComponent(CustomButton).exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('Complex Button');
+  });
+
+  test('can simulate external functionality in a component using mocks', async () => {
+    const mockPush = vi.fn();
+
+    const wrapper = await mountSuspendedComponent(MockTestComponent, {
+      mocks: {
+        $router: {
+          push: mockPush,
+        },
+      },
+    });
+
+    await wrapper.find('button').trigger('click');
+    expect(mockPush).toHaveBeenCalledWith('/test');
+  });
+});

--- a/src/__test__/helpers/test/setupTestingPinia.spec.ts
+++ b/src/__test__/helpers/test/setupTestingPinia.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+import { setupTestingPinia } from '@/helpers/test';
+
+const useTestStore = defineStore('test', {
+  state: () => ({
+    count: 0,
+    name: 'test',
+  }),
+  actions: {
+    increment() {
+      this.count++;
+    },
+    updateName(name: string) {
+      this.name = name;
+    },
+  },
+});
+
+describe('src/helpers/test/setupTestingPinia.ts', () => {
+  test('creates a Pinia instance with empty initial state', () => {
+    const testingPinia = setupTestingPinia();
+
+    expect(testingPinia).toBeDefined();
+
+    const testStore = useTestStore(testingPinia);
+
+    expect(testStore.count).toBe(0);
+    expect(testStore.name).toBe('test');
+
+    testStore.increment();
+    testStore.updateName('newName');
+
+    expect(testStore.count).toBe(1);
+    expect(testStore.name).toBe('newName');
+  });
+
+  test('creates a Pinia instance with custom initial state', () => {
+    const initialState = {
+      test: {
+        count: 5,
+        name: 'initialName',
+      },
+    };
+
+    const testingPinia = setupTestingPinia(initialState);
+
+    expect(testingPinia).toBeDefined();
+
+    const testStore = useTestStore();
+
+    expect(testStore.count).toBe(5);
+    expect(testStore.name).toBe('initialName');
+
+    testStore.increment();
+    testStore.updateName('updatedName');
+
+    expect(testStore.count).toBe(6);
+    expect(testStore.name).toBe('updatedName');
+  });
+});

--- a/src/helpers/test/index.ts
+++ b/src/helpers/test/index.ts
@@ -1,0 +1,3 @@
+export { mountComponent, mountSuspendedComponent } from './mount';
+export { setupTestingPinia } from './setupTestingPinia';
+export { mockedStore } from './mockedStore';

--- a/src/helpers/test/mockedStore.ts
+++ b/src/helpers/test/mockedStore.ts
@@ -1,0 +1,25 @@
+import type { Store, StoreDefinition } from 'pinia';
+import type { Mock } from 'vitest';
+import type { UnwrapRef } from 'vue';
+
+export const mockedStore = <TStoreDef extends () => unknown>(
+  useStore: TStoreDef,
+): TStoreDef extends StoreDefinition<infer Id, infer State, infer Getters, infer Actions>
+  ? Store<
+      Id,
+      State,
+      Record<string, never>,
+      {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        [K in keyof Actions]: Actions[K] extends (...args: any[]) => any
+          ? // 👇 depends on your testing framework
+            Mock<Actions[K]>
+          : Actions[K];
+      }
+    > & {
+      [K in keyof Getters]: UnwrapRef<Getters[K]>;
+    }
+  : ReturnType<TStoreDef> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return useStore() as any;
+};

--- a/src/helpers/test/mount.ts
+++ b/src/helpers/test/mount.ts
@@ -1,0 +1,148 @@
+/**
+ * Utility module for mounting Vue components in tests
+ * Provides helper functions to easily mount components with common testing configurations
+ */
+
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { mount, RouterLinkStub, type VueWrapper } from '@vue/test-utils';
+import type { setupTestingPinia } from './setupTestingPinia';
+import type { Component, ComponentPublicInstance, DefineComponent, Slots } from 'vue';
+
+/** Interface defining options for mounting components in tests */
+interface MountOptions {
+  /** Pinia store instance for testing */
+  testingPinia?: ReturnType<typeof setupTestingPinia>;
+  /** Element to attach the component to */
+  attachTo?: Element | string;
+  /** Component props */
+  props?: Record<string, unknown>;
+  /** Component slots */
+  slots?: Record<string, () => VNode | VNode[] | string> | Slots;
+  /** Whether to use shallow mounting */
+  shallow?: boolean;
+  /** Components to stub */
+  stubs?: Record<string, Component | boolean>;
+  /** Properties to mock */
+  mocks?: Record<string, unknown>;
+  /** Global configuration */
+  config?: Record<string, unknown>;
+  /** Additional mounting options */
+  options?: Record<string, unknown>;
+}
+
+/**
+ * Default stubs used when mounting components
+ * NuxtLink is automatically stubbed with RouterLinkStub
+ */
+const DEFAULT_STUBS = {
+  NuxtLink: RouterLinkStub,
+} as const;
+
+/**
+ * Default options used when mounting components
+ * Provides reasonable defaults for all mount options
+ */
+const DEFAULT_OPTIONS = {
+  testingPinia: undefined,
+  attachTo: undefined,
+  props: {},
+  slots: {},
+  shallow: false,
+  stubs: DEFAULT_STUBS,
+  mocks: {},
+  config: {},
+  options: {},
+} as const satisfies MountOptions;
+
+/**
+ * Mounts a Vue component for testing with specified options
+ *
+ * @template VMValue - Type to extend the component instance with
+ * @param component - The Vue component to mount
+ * @param options {@link MountOptions} - Options for mounting the component
+ * @returns Mounted component wrapper
+ *
+ * @example
+ * const wrapper = mountComponent(MyComponent, {
+ *   props: { title: 'Test' },
+ *   testingPinia
+ * });
+ */
+export const mountComponent = <VMValue>(
+  component: Component,
+  options: Partial<MountOptions> = DEFAULT_OPTIONS,
+): VueWrapper<ComponentPublicInstance & VMValue & DefineComponent> => {
+  const mergedOptions = { ...DEFAULT_OPTIONS, ...options };
+  const {
+    testingPinia,
+    attachTo,
+    props,
+    slots,
+    shallow,
+    stubs,
+    mocks,
+    config,
+    options: additionalOptions,
+  } = mergedOptions;
+
+  return mount(component, {
+    ...additionalOptions,
+    attachTo,
+    props,
+    slots,
+    shallow,
+    global: {
+      plugins: testingPinia ? [testingPinia] : [],
+      stubs: { ...DEFAULT_STUBS, ...stubs },
+      mocks,
+      config,
+    },
+  });
+};
+
+/**
+ * Mounts a Vue component that uses suspense for testing with specified options
+ * This is useful for components that use async setup() or async components
+ *
+ * @template VMValue - Type to extend the component instance with
+ * @param component - The Vue component to mount
+ * @param options {@link MountOptions} - Options for mounting the component
+ * @returns Promise resolving to mounted component wrapper
+ *
+ * @example
+ * const wrapper = await mountSuspendedComponent(MyAsyncComponent, {
+ *   props: { id: '123' },
+ *   testingPinia
+ * });
+ */
+export const mountSuspendedComponent = async <VMValue>(
+  component: Component,
+  options: Partial<MountOptions> = DEFAULT_OPTIONS,
+): Promise<VueWrapper<ComponentPublicInstance & VMValue & DefineComponent>> => {
+  const mergedOptions = { ...DEFAULT_OPTIONS, ...options };
+  const {
+    testingPinia,
+    attachTo,
+    props,
+    slots,
+    shallow,
+    stubs,
+    mocks,
+    config,
+    options: additionalOptions,
+  } = mergedOptions;
+
+  return await mountSuspended(component, {
+    ...additionalOptions,
+    attachTo,
+    props,
+    slots,
+    shallow,
+    global: {
+      plugins: testingPinia ? [testingPinia] : [],
+      stubs: { ...DEFAULT_STUBS, ...stubs },
+      mocks,
+      config,
+    },
+  });
+};

--- a/src/helpers/test/setupTestingPinia.ts
+++ b/src/helpers/test/setupTestingPinia.ts
@@ -1,0 +1,22 @@
+import { createTestingPinia, type TestingPinia } from '@pinia/testing';
+import { vi } from 'vitest';
+import type { StateTree } from 'pinia';
+
+/**
+ * Helper function to create a Pinia instance for testing
+ *
+ * @param initialState Object to set the initial state of the store (optional)
+ * @returns Pinia instance configured for testing
+ *
+ * @example
+ * const testingPinia = setupTestingPinia();
+ * const wrapper = mountComponent(TestComponent, { testingPinia });
+ */
+export const setupTestingPinia = (initialState: StateTree = {}): TestingPinia => {
+  const testingPinia = createTestingPinia({
+    stubActions: false,
+    createSpy: vi.fn,
+    initialState,
+  });
+  return testingPinia;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Vueコンポーネントのテスト用ユーティリティ（mountComponent、mountSuspendedComponent、setupTestingPinia、mockedStore）を追加しました。
  - Piniaストアのモックやテスト用セットアップを簡単に行えるようになりました。

- **テスト**
  - VueコンポーネントとPiniaストアの包括的なユニットテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->